### PR TITLE
Chore/test props only for vscode bump templatedx

### DIFF
--- a/.changeset/funny-apes-impress.md
+++ b/.changeset/funny-apes-impress.md
@@ -1,0 +1,5 @@
+---
+"@puzzlet/promptdx": patch
+---
+
+TemplateDX bump, make test props for extensions only

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "vitest": "^2.1.1"
   },
   "dependencies": {
-    "@puzzlet/templatedx": "^0.1.0",
+    "@puzzlet/templatedx": "^0.2.0",
     "front-matter": "^4.0.2",
     "js-yaml": "^4.1.0",
     "openai": "^4.65.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,9 @@ export {
   getModel,
 } from "./runtime";
 
+export { toFrontMatter } from './utils';
+
+export type { Output } from "./types";
+export type { PromptDX } from "./runtime";
+
 export { ModelPluginRegistry } from "./model-plugin-registry";

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -19,19 +19,18 @@ export interface PromptDX {
       name: string;
       settings: JSONObject;
     };
-    props: JSONObject;
   };
 }
 
-async function loadMdx(ast: Ast, props?: JSONObject) {
+async function loadMdx(ast: Ast, props = {}) {
   const frontMatter: any = getFrontMatter(ast);
-  const newProps = { ...(frontMatter.metadata.props || {}), ...(props || {}) };
-  const extractedFields = await extractFields(ast, ["User", "System", "Assistant"], newProps);
+  const extractedFields = await extractFields(ast, ["User", "System", "Assistant"], props);
   const messages = extractedFields.map((field) => ({ role: field.name.toLocaleLowerCase(), content: field.content }))
 
-  if (!frontMatter.metadata || !frontMatter.name || !extractedFields.length) {
-    throw new Error(`Invalid prompt.`);
-  }
+  if (!frontMatter.metadata) throw new Error(`Prompt must contain metadata`);
+  if (!frontMatter.name) throw new Error(`Prompt must have a name`);
+  if (!extractFields.length) throw new Error(`Prompt messages must not be empty.`);
+  if (!frontMatter.metadata.model) throw new Error(`Prompt metadata must contain model info`);
 
   const promptDX: PromptDX = {
     name: frontMatter.name,
@@ -61,8 +60,8 @@ export function serialize(
   return plugin?.serialize(completionParams, promptName);
 }
 
-export async function deserialize(ast: Ast) {
-  const promptDX = await loadMdx(ast);
+export async function deserialize(ast: Ast, props = {}) {
+  const promptDX = await loadMdx(ast, props);
   const plugin = ModelPluginRegistry.getPlugin(
     promptDX.metadata.model.name
   );

--- a/src/test/mdx/with-history.prompt.mdx
+++ b/src/test/mdx/with-history.prompt.mdx
@@ -6,6 +6,7 @@ metadata:
     settings:
       top_p: 1
       temperature: 0.7
+test_settings:
   props:
     messageHistory:
       - role: system

--- a/src/test/openai.test.ts
+++ b/src/test/openai.test.ts
@@ -4,6 +4,7 @@ import "../builtin-plugins";
 import { runInference, deserialize, serialize } from "../runtime";
 import { vi } from "vitest";
 import { openAIResponseWithNoStream, openAIResponseWithStream } from "./utils";
+import { getFrontMatter } from "@puzzlet/templatedx";
 
 vi.stubEnv("OPENAI_API_KEY", "key");
 
@@ -211,9 +212,11 @@ const promptWithHistory = {
   ],
 };
 
-test("should deserialize prompt with history", async () => {
+test("should deserialize prompt with history prop", async () => {
   const ast = await getMdxAst(__dirname + "/mdx/with-history.prompt.mdx");
-  const deserializedPrompt = await deserialize(ast);
+  const frontMatter = getFrontMatter(ast) as any;
+  const props = frontMatter.test_settings.props;
+  const deserializedPrompt = await deserialize(ast, props);
 
   expect(deserializedPrompt).toEqual(promptWithHistory);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,14 +1186,15 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@puzzlet/templatedx@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@puzzlet/templatedx/-/templatedx-0.1.0.tgz#d7b39640fe33a21d4d688d02ec3168f4c9b43144"
-  integrity sha512-VpvYBjKZ+BAKsRZ3TOeIXqKM01WlnNfrU1zNT7VjE+t2z/zrUI/UGfN1PIunG1Hhy9Rts8dxCLgrDDJ5G4dNHw==
+"@puzzlet/templatedx@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@puzzlet/templatedx/-/templatedx-0.2.0.tgz#d9900ac544d6c5a5a340d34ca52fbba05a9b586d"
+  integrity sha512-koRWQ3ounn7XzbCIlX03cetkApgJCoWw0fk/BjcrP/o01Bj2BMEOmKpnNgEV+W2X/YT80ybHvxE9xJJSR3lWLg==
   dependencies:
     js-yaml "^4.1.0"
     jsep "^1.3.9"
     mdast "^3.0.0"
+    mdast-util-to-markdown "^2.1.0"
     remark-frontmatter "^5.0.0"
     remark-mdx "^3.0.1"
     remark-parse "^11.0.0"
@@ -2187,7 +2188,7 @@ mdast-util-phrasing@^4.0.0:
     "@types/mdast" "^4.0.0"
     unist-util-is "^6.0.0"
 
-mdast-util-to-markdown@^2.0.0:
+mdast-util-to-markdown@^2.0.0, mdast-util-to-markdown@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.0.tgz#9813f1d6e0cdaac7c244ec8c6dabfdb2102ea2b4"
   integrity sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==


### PR DESCRIPTION
## Description

Test props in file are now for vscode extension. This means they will no longer act as defaults, and must be passed into PromptDX.

Also, bump TemplateDX

Fixes # (issue)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
