### PR TITLE
Feat/expose rawconfig

### DIFF
--- a/.changeset/famous-islands-return.md
+++ b/.changeset/famous-islands-return.md
@@ -1,0 +1,5 @@
+---
+"@puzzlet/promptdx": minor
+---
+
+Export getRawConfig for consumers

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {
   deserialize,
   serialize,
   registerDefaultPlugins,
+  getConfig,
   getModel,
 } from "./runtime";
 export { parse } from "@puzzlet/templatedx";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export {
   deserialize,
   serialize,
   registerDefaultPlugins,
-  getConfig,
+  getRawConfig,
   getModel,
 } from "./runtime";
 export { parse } from "@puzzlet/templatedx";

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -31,7 +31,7 @@ type SharedContext = {
 
 TagPluginRegistry.register(new ExtractTextPlugin(), ["User", "System", "Assistant"]);
 
-async function loadMdx(ast: Ast, props = {}) {
+export async function getConfig(ast: Ast, props = {}) {
   const frontMatter: any = getFrontMatter(ast);
   const shared: SharedContext = {};
   await transform(ast, props, shared);
@@ -55,7 +55,7 @@ export async function runInference(
   ast: Ast,
   props: JSONObject = {},
 ) {
-  const promptDX = await loadMdx(ast, props);
+  const promptDX = await getConfig(ast, props);
   const plugin = ModelPluginRegistry.getPlugin(
     promptDX.metadata.model.name
   );
@@ -75,7 +75,7 @@ export function serialize(
 }
 
 export async function deserialize(ast: Ast, props = {}) {
-  const promptDX = await loadMdx(ast, props);
+  const promptDX = await getConfig(ast, props);
   const plugin = ModelPluginRegistry.getPlugin(
     promptDX.metadata.model.name
   );

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -31,7 +31,7 @@ type SharedContext = {
 
 TagPluginRegistry.register(new ExtractTextPlugin(), ["User", "System", "Assistant"]);
 
-export async function getConfig(ast: Ast, props = {}) {
+export async function getRawConfig(ast: Ast, props = {}) {
   const frontMatter: any = getFrontMatter(ast);
   const shared: SharedContext = {};
   await transform(ast, props, shared);
@@ -55,7 +55,7 @@ export async function runInference(
   ast: Ast,
   props: JSONObject = {},
 ) {
-  const promptDX = await getConfig(ast, props);
+  const promptDX = await getRawConfig(ast, props);
   const plugin = ModelPluginRegistry.getPlugin(
     promptDX.metadata.model.name
   );
@@ -75,7 +75,7 @@ export function serialize(
 }
 
 export async function deserialize(ast: Ast, props = {}) {
-  const promptDX = await getConfig(ast, props);
+  const promptDX = await getRawConfig(ast, props);
   const plugin = ModelPluginRegistry.getPlugin(
     promptDX.metadata.model.name
   );

--- a/src/test/mdx/history.mdx
+++ b/src/test/mdx/history.mdx
@@ -1,13 +1,3 @@
-{/**
-  * @typedef MessageItem
-  * @property {"user" | "assistant"} role
-  * @property {string} message
-  */}
-{/**
-  * @typedef Props
-  * @property {Array<MessageItem>} messageHistory
-  */}
-
 <ForEach arr={props.messageHistory}>
   {(item) => (
     <>

--- a/src/test/mdx/message-item.mdx
+++ b/src/test/mdx/message-item.mdx
@@ -1,12 +1,3 @@
-{/**
-  * @typedef MessageItem
-  * @property {"user" | "assistant"} role
-  * @property {string} message
-  */}
-{/**
-  * @typedef Props
-  * @property {MessageItem} item
-  */}
 <If condition={props.item.role == 'user'}>
   <User>{props.item.message}</User>
 </If>

--- a/src/test/mdx/with-history.prompt.mdx
+++ b/src/test/mdx/with-history.prompt.mdx
@@ -20,15 +20,6 @@ test_settings:
       - role: assistant
         message: 5
 ---
-{/**
-  * @typedef MessageItem
-  * @property {"user" | "assistant"} role
-  * @property {string} message
-  */}
-{/**
-  * @typedef Props
-  * @property {Array<MessageItem>} messageHistory
-  */}
 import MessageHistory from './history.mdx';
 
 <MessageHistory messageHistory={props.messageHistory} />


### PR DESCRIPTION
## Description

Exposes `getRawConfig` for consumers. Allows them to access messages, config, model, etc. Removing type safety from MDX files.

Fixes # (issue)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
