### PR TITLE
Feat/vscode chat

### DIFF
--- a/src/test/mdx/with-history.prompt.mdx
+++ b/src/test/mdx/with-history.prompt.mdx
@@ -7,20 +7,12 @@ metadata:
       top_p: 1
       temperature: 0.7
 test_settings:
-  props:
-    messageHistory:
-      - role: system
-        message: ignored
-      - role: user
-        message: What's 2 + 2?
-      - role: assistant
-        message: 5
-      - role: user
-        message: What's 10 + 2?
-      - role: assistant
-        message: 5
+  chat:
+    useChat: true
+    chatField: messageHistory
+    maxSize: 10
 ---
 import MessageHistory from './history.mdx';
 
 <MessageHistory messageHistory={props.messageHistory} />
-<User>Why are you bad at math?</User>
+<User>What is the previous answer + 3?</User>

--- a/src/test/mdx/with-history.prompt.mdx
+++ b/src/test/mdx/with-history.prompt.mdx
@@ -7,12 +7,20 @@ metadata:
       top_p: 1
       temperature: 0.7
 test_settings:
-  chat:
-    useChat: true
-    chatField: messageHistory
-    maxSize: 10
+  props:
+    messageHistory:
+      - role: system
+        message: ignored
+      - role: user
+        message: What's 2 + 2?
+      - role: assistant
+        message: 5
+      - role: user
+        message: What's 10 + 2?
+      - role: assistant
+        message: 5
 ---
 import MessageHistory from './history.mdx';
 
 <MessageHistory messageHistory={props.messageHistory} />
-<User>What is the previous answer + 3?</User>
+<User>Why are you bad at math?</User>

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "PromptDX",
   "publisher": "puzzlet",
   "description": "A declarative, extensible, and composable approach for developing LLM prompts using Markdown and JSX.",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "repository": "https://github.com/puzzlet-ai/promptdx",
   "license": "MIT",
   "icon": "static/logo.png",
@@ -71,7 +71,7 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "@puzzlet/promptdx": "^0.1.5",
+    "@puzzlet/promptdx": "^0.2.0",
     "@puzzlet/templatedx": "^0.5.7"
   }
 }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "PromptDX",
   "publisher": "puzzlet",
   "description": "A declarative, extensible, and composable approach for developing LLM prompts using Markdown and JSX.",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "repository": "https://github.com/puzzlet-ai/promptdx",
   "license": "MIT",
   "icon": "static/logo.png",

--- a/vscode-extension/src/boundedQueue.ts
+++ b/vscode-extension/src/boundedQueue.ts
@@ -1,0 +1,19 @@
+export function createBoundedQueue<T>(maxLength: number) {
+  if (maxLength <= 0) {
+      throw new Error("Max length must be greater than 0.");
+  }
+
+  const queue: T[] = [];
+
+  return {
+      add(item: T) {
+          if (queue.length >= maxLength) {
+              queue.shift(); // Remove the oldest item
+          }
+          queue.push(item);
+      },
+      getItems() {
+          return [...queue];
+      }
+  };
+}

--- a/vscode-extension/yarn.lock
+++ b/vscode-extension/yarn.lock
@@ -287,10 +287,10 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@puzzlet/promptdx@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@puzzlet/promptdx/-/promptdx-0.1.5.tgz#6b97b3ec3cb885b52c71d03e58e436a05fd66b15"
-  integrity sha512-OcETEZc2hAdQqREXjr4yVHmoRAccJOgUYZskYXUcrqHKVo7NPX3z8BLNB0E6L1HtCDve+sAxD3NWuO3oiOAl7g==
+"@puzzlet/promptdx@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@puzzlet/promptdx/-/promptdx-0.2.0.tgz#632985faf72e341fbd156c9029f0eb1b991cef83"
+  integrity sha512-+9Ps2MbEKGJx80ZaxFVYhnYuuIdptXw+2jS/CqZXIEjeCZX6YFzgq3CjYzVwWu7PQKe+mzcpqee+oOD+CRZ0oA==
   dependencies:
     "@puzzlet/templatedx" "^0.5.7"
     front-matter "^4.0.2"


### PR DESCRIPTION
## Description

Allows you to chat with a promptdx file via VSCode. The extension maintains configurable chat history, w/ some set max size.

Fixes: https://github.com/puzzlet-ai/promptdx/issues/38

To use:

```
---
name: basic-prompt
metadata:
  model:
    name: gpt-4o-mini
    settings:
      top_p: 1
      temperature: 0.7
test_settings:
  chat:
    useChat: true
    chatField: messageHistory
    maxSize: 10
---

Note in the above, we'll use chat, with a max history size of 10, and it'll be passed in the `messageHistory` field.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
